### PR TITLE
Update package.json main to point to dist css file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/BioPhoton/css-star-rating/issues"
   },
   "homepage": "https://github.com/BioPhoton/css-star-rating#readme",
-  "main": "dist/index.js",
+  "main": "dist/css/star-rating.css",
   "devDependencies": {
     "angularic-ionicon": "^1.1.0",
     "conventional-changelog": "^1.1.0",


### PR DESCRIPTION
package.json's `main` currently points to the non-existant dist/index.js file. The real main entry point for css-star-rating is the css file itself. By setting that to the main, it can be easily integrated with projects that support loading node modules (such as by using WebPack) as a simple `@import 'css-star-rating'`.