### PR TITLE
Mark Range variables as Default

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -4,9 +4,9 @@
 ====================================================*/
 
 /*Range*/
-$minRatingValue: 1;
-$maxNumOfStars: 6;
-$numFractions: 3;
+$minRatingValue: 1 !default;
+$maxNumOfStars: 6 !default;
+$numFractions: 3 !default;
 $fractionSize: $maxNumOfStars/$numFractions;
 
 /*Spacing*/


### PR DESCRIPTION
Allows range variables (specifically maxNumOfStars) to be overridden by the importing SCSS file.

Fixes https://github.com/BioPhoton/angular-star-rating/issues/61